### PR TITLE
Fix paging options for survey responses

### DIFF
--- a/Resources/Survey.php
+++ b/Resources/Survey.php
@@ -236,7 +236,8 @@ class Survey extends ApiResource
 	 */
 	private function getSubObjects($type, $filter = null, $options = null)
 	{
-		$options = array("survey_id" => $this->id);
+		$options = (isset($options))? $options: [];
+		$options["survey_id"] = $this->id;
 		return $type::fetch($this->id, $filter, $options);
 	}
 

--- a/Resources/Survey.php
+++ b/Resources/Survey.php
@@ -236,7 +236,7 @@ class Survey extends ApiResource
 	 */
 	private function getSubObjects($type, $filter = null, $options = null)
 	{
-		$options = (isset($options))? $options: [];
+		$options = (isset($options))? $options: array();
 		$options["survey_id"] = $this->id;
 		return $type::fetch($this->id, $filter, $options);
 	}


### PR DESCRIPTION
The options array was being overwritten in the getSubObjects function.
I added a line to set the options to an empty array if it is null, then set the survey_id.
