### PR TITLE
Throwing exceptions without message throws PHP fatal errors

### DIFF
--- a/ApiRequest.php
+++ b/ApiRequest.php
@@ -133,7 +133,7 @@ class ApiRequest
 				$this->request_return = json_decode($buffer);
 			}
 		} catch (Exception $e) {
-			new SurveyGizmoException(500, "CURL error", $e);
+			new SurveyGizmoException("CURL error", 500, $e);
 		}
 	}
 
@@ -162,20 +162,20 @@ class ApiRequest
 	{
 		// The API URL must be set
 		if (!self::$API_URL) {
-			new SurveyGizmoException(500, "ApiRequest: API URL required");
+			new SurveyGizmoException("ApiRequest: API URL required", 500);
 		}
 		// The API resource URL must be set
 		if (!$this->path) {
-			new SurveyGizmoException(500, "ApiRequest: resource URL required");
+			new SurveyGizmoException("ApiRequest: resource URL required", 500);
 		}
 		// The request must be one of the 4 types
 		if (!in_array($this->method, array('GET', 'POST', 'PUT', 'DELETE'))) {
-			new SurveyGizmoException(500, "ApiRequest: invalid method type");
+			new SurveyGizmoException("ApiRequest: invalid method type", 500);
 		}
 		// The API credentials must be set prior to making a request
 		$creds = SurveyGizmoAPI::getAuth();
 		if (!$creds['AuthToken'] || !$creds['AuthSecret']) {
-			new SurveyGizmoException(500, "ApiRequest: API credentials are required");
+			new SurveyGizmoException("ApiRequest: API credentials are required", 500);
 		}
 
 		// Construct the array of parameters

--- a/ApiResource.php
+++ b/ApiResource.php
@@ -55,7 +55,7 @@ class ApiResource
 		// Return the modified ApiResponse
 		return $response;
 	}
-	
+
 	/**
 	 * Returns the specific instance of a resource using an HTTP GET.
 	 * @access public
@@ -147,10 +147,10 @@ class ApiResource
 	 */
 	public function _delete($params = null)
 	{
-		// Determine whether this object actually exists in the API. Override the `exists` 
+		// Determine whether this object actually exists in the API. Override the `exists`
 		// method in the resource classes to change the behavior
 		if (!$this->exists()) {
-			throw new SurveyGizmoException(500, "Resource does not exist");
+			throw new SurveyGizmoException("Resource does not exist", 500);
 		}
 		// Get the URL string
 		$path = self::_mergePath(static::$path, $params);
@@ -242,7 +242,7 @@ class ApiResource
 	 */
 	public static function fetch()
 	{
-		throw new SurveyGizmoException(SurveyGizmoException::NOT_SUPPORTED);
+		throw new SurveyGizmoException('', SurveyGizmoException::NOT_SUPPORTED);
 	}
 
 	/**
@@ -255,29 +255,29 @@ class ApiResource
 	 */
 	public static function get()
 	{
-		throw new SurveyGizmoException(SurveyGizmoException::NOT_SUPPORTED);
+		throw new SurveyGizmoException('', SurveyGizmoException::NOT_SUPPORTED);
 	}
 
 	/**
 	 * Save the instance of this resource. By default this method is not supported.
-	 * Extend in order to change behavior. 
+	 * Extend in order to change behavior.
 	 * @access public
 	 * @return SurveyGizmo\Helpers\ApiResponse
 	 */
 	public function save()
 	{
-		throw new SurveyGizmoException(SurveyGizmoException::NOT_SUPPORTED);
+		throw new SurveyGizmoException('', SurveyGizmoException::NOT_SUPPORTED);
 	}
 
 	/**
 	 * Deletes the instance of this resource. By default this method is not supported.
-	 * Extend in order to change behavior. 
+	 * Extend in order to change behavior.
 	 * @access public
 	 * @return SurveyGizmo\Helpers\ApiResponse
 	 */
 	public function delete()
 	{
-		throw new SurveyGizmoException(SurveyGizmoException::NOT_SUPPORTED);
+		throw new SurveyGizmoException('', SurveyGizmoException::NOT_SUPPORTED);
 	}
 
 }

--- a/Helpers/SurveyGizmoException.php
+++ b/Helpers/SurveyGizmoException.php
@@ -14,7 +14,7 @@ class SurveyGizmoException extends Exception
 	// Used for HTTP-like status code
 	protected $code = 500;
 
-	public function __construct($code = 0, $message = "", Exception $previous = null) {
+	public function __construct($message = "", $code = 0, Exception $previous = null) {
 		parent::__construct($message, $code, $previous);
 
 		// Default the message based on code (if empty)

--- a/Helpers/SurveyGizmoException.php
+++ b/Helpers/SurveyGizmoException.php
@@ -14,8 +14,7 @@ class SurveyGizmoException extends Exception
 	// Used for HTTP-like status code
 	protected $code = 500;
 
-	// Redefine the exception so code is first parameter
-	public function __construct($code = 0, $message, Exception $previous = null) {
+	public function __construct($code = 0, $message = "", Exception $previous = null) {
 		parent::__construct($message, $code, $previous);
 
 		// Default the message based on code (if empty)

--- a/Resources/ContactList.php
+++ b/Resources/ContactList.php
@@ -50,7 +50,7 @@ class ContactList extends ApiResource
 	{
 		$id = (int) $id;
 		if ($id < 1) {
-			throw new SurveyGizmoException(500, "Contact List ID required");
+			throw new SurveyGizmoException("Contact List ID required", 500);
 		}
 		return self::_get(array(
 			'id' => $id

--- a/Resources/ContactList/Contact.php
+++ b/Resources/ContactList/Contact.php
@@ -23,10 +23,10 @@ class Contact extends ApiResource
 	public function save()
 	{
 		if ((int) $this->list_id < 1) {
-			throw new SurveyGizmoException(500, "Contact needs to belong to a contact list");
+			throw new SurveyGizmoException("Contact needs to belong to a contact list", 500);
 		}
 		if (empty($this->email_address)) {
-			throw new SurveyGizmoException(500, "Contact requires an email");
+			throw new SurveyGizmoException("Contact requires an email", 500);
 		}
 		return $this->_save(array(
 			'id' => $this->id,
@@ -42,7 +42,7 @@ class Contact extends ApiResource
 	public function delete()
 	{
 		if ((int) $this->list_id < 1) {
-			throw new SurveyGizmoException(500, "Contact needs to belong to a contact list");
+			throw new SurveyGizmoException("Contact needs to belong to a contact list", 500);
 		}
 		return self::_delete(array(
 			'id' => $this->id,
@@ -63,7 +63,7 @@ class Contact extends ApiResource
 		$list_id = (int) $list_id;
 		$id = (int) $id;
 		if ($id < 1 || $list_id < 1) {
-			throw new SurveyGizmoException(500, "Contact list ID and contact ID required");
+			throw new SurveyGizmoException("Contact list ID and contact ID required", 500);
 		}
 		return self::_get(array(
 			'id' => $id,
@@ -84,7 +84,7 @@ class Contact extends ApiResource
 	{
 		$list_id = (int) $list_id;
 		if ($list_id < 1) {
-			throw new SurveyGizmoException(500, "Contact list ID required");
+			throw new SurveyGizmoException("Contact list ID required", 500);
 		}
 		return self::_fetch(array(
 			'id' => '',

--- a/Resources/Survey.php
+++ b/Resources/Survey.php
@@ -53,7 +53,7 @@ class Survey extends ApiResource
 	public static function get($id = null)
 	{
 		if ($id < 1) {
-			throw new SurveyGizmoException(500, "ID required");
+			throw new SurveyGizmoException("ID required", 500);
 		}
 		return self::_get(array(
 			'id' => $id

--- a/Resources/Survey/Campaign.php
+++ b/Resources/Survey/Campaign.php
@@ -25,7 +25,7 @@ class Campaign extends ApiResource
 	 */
 	public static function fetch($survey_id = null, $filter = null, $options = null) {
 		if ($survey_id < 1) {
-			throw new SurveyGizmoException(500, "Missing survey ID");
+			throw new SurveyGizmoException("Missing survey ID", 500);
 		}
 		$response = self::_fetch(array('id' => '', 'survey_id' => $survey_id), $filter, $options);
 		return $response;
@@ -40,7 +40,7 @@ class Campaign extends ApiResource
 	 */
 	public static function get($survey_id = null, $id = null){
 		if ($id < 1 && $survey_id < 1) {
-			throw new SurveyGizmoException(500, "IDs required");
+			throw new SurveyGizmoException("IDs required", 500);
 		}
 		return self::_get(array(
 			'survey_id' => $survey_id,

--- a/Resources/Survey/EmailMessage.php
+++ b/Resources/Survey/EmailMessage.php
@@ -26,7 +26,7 @@ class EmailMessage extends ApiResource
 	 */
 	public static function fetch($survey_id = null, $campaign_id = null, $filter = null, $options = null) {
 		if ($campaign_id < 1 && $survey_id < 1) {
-			throw new SurveyGizmoException(500, "Missing campaign or survey ID");
+			throw new SurveyGizmoException("Missing campaign or survey ID", 500);
 		}
 		$response = self::_fetch(array('id' => '', 'survey_id' => $survey_id, 'campaign_id' => $campaign_id,), $filter, $options);
 		return $response;
@@ -42,7 +42,7 @@ class EmailMessage extends ApiResource
 	 */
 	public static function get($survey_id = null, $campaign_id = null, $id = null){
 		if ($id < 1 && $survey_id < 1 && $campaign_id < 1) {
-			throw new SurveyGizmoException(500, "IDs required");
+			throw new SurveyGizmoException("IDs required", 500);
 		}
 		return self::_get(array(
 			'campaign_id' => $campaign_id,

--- a/Resources/Survey/Page.php
+++ b/Resources/Survey/Page.php
@@ -25,7 +25,7 @@ class Page extends ApiResource {
 	 */
 	public static function fetch($survey_id = null, $filter = null, $options = null) {
 		if ($survey_id < 1) {
-			throw new SurveyGizmoException(500, "Missing survey ID");
+			throw new SurveyGizmoException("Missing survey ID", 500);
 		}
 		$response = self::_fetch(array('id' => '', 'survey_id' => $survey_id), $filter, $options);
 		return $response;
@@ -40,7 +40,7 @@ class Page extends ApiResource {
 	 */
 	public static function get($survey_id = null, $id = null){
 		if ($id < 1 && $survey_id < 1) {
-			throw new SurveyGizmoException(500, "IDs required");
+			throw new SurveyGizmoException("IDs required", 500);
 		}
 		return self::_get(array(
 			'survey_id' => $survey_id,

--- a/Resources/Survey/Question.php
+++ b/Resources/Survey/Question.php
@@ -40,7 +40,7 @@ class Question extends ApiResource {
 	 */
 	public static function fetch($survey_id = null, $filter = null, $options = null) {
 		if ($survey_id < 1) {
-			throw new SurveyGizmoException(500, "Missing survey ID");
+			throw new SurveyGizmoException("Missing survey ID", 500);
 		}
 		$response = self::_fetch(array('id' => '', 'survey_id' => $survey_id), $filter, $options);
 		return $response;
@@ -55,7 +55,7 @@ class Question extends ApiResource {
 	 */
 	public static function get($survey_id = null, $id = null){
 		if ($id < 1 && $survey_id < 1) {
-			throw new SurveyGizmoException(500, "IDs required");
+			throw new SurveyGizmoException("IDs required", 500);
 		}
 		return self::_get(array(
 			'survey_id' => $survey_id,

--- a/Resources/Survey/Report.php
+++ b/Resources/Survey/Report.php
@@ -26,7 +26,7 @@ class Report extends ApiResource
 	 */
 	public static function fetch($survey_id = null, $filter = null, $options = null) {
 		if ($survey_id < 1) {
-			throw new SurveyGizmoException(500, "Missing survey ID");
+			throw new SurveyGizmoException("Missing survey ID", 500);
 		}
 		$response = self::_fetch(array('id' => '', 'survey_id' => $survey_id), $filter, $options);
 		return $response;
@@ -42,7 +42,7 @@ class Report extends ApiResource
 	public static function get($survey_id = null, $id = null)
 	{
 		if ($survey_id < 1 || $id < 1) {
-                        throw new SurveyGizmoException(500, "Missing survey ID and/or report ID");
+                        throw new SurveyGizmoException("Missing survey ID and/or report ID", 500);
                 }
 		return self::_get(array(
 			'survey_id' => $survey_id,

--- a/Resources/Survey/Response.php
+++ b/Resources/Survey/Response.php
@@ -40,7 +40,7 @@ class Response extends ApiResource {
 	 */
 	public static function fetch($survey_id = null, $filter = null, $options = null) {
 		if ($survey_id < 1) {
-			throw new SurveyGizmoException(500, "Missing survey ID");
+			throw new SurveyGizmoException("Missing survey ID", 500);
 		}
 		$response = self::_fetch(array('id' => '', 'survey_id' => $survey_id), $filter, $options);
 		return $response;

--- a/Resources/Survey/Statistics.php
+++ b/Resources/Survey/Statistics.php
@@ -19,7 +19,7 @@ class Statistics extends ApiResource {
 
 	public static function fetch($survey_id = null){
 		if($survey_id < 1){
-			throw new SurveyGizmoException(500, "Survey ID required");
+			throw new SurveyGizmoException("Survey ID required", 500);
 		}
 		return self::_fetch(array(
 			'survey_id' => $survey_id

--- a/Resources/Team.php
+++ b/Resources/Team.php
@@ -49,7 +49,7 @@ class Team extends ApiResource
 	{
 		$id = (int) $id;
 		if ($id < 1) {
-			throw new SurveyGizmoException(500, "Team ID required");
+			throw new SurveyGizmoException("Team ID required", 500);
 		}
 		return self::_get(array(
 			'id' => $id

--- a/Resources/User.php
+++ b/Resources/User.php
@@ -49,7 +49,7 @@ class User extends ApiResource
 	{
 		$id = (int) $id;
 		if ($id < 1) {
-			throw new SurveyGizmoException(500, "User ID required");
+			throw new SurveyGizmoException("User ID required", 500);
 		}
 		return self::_get(array(
 			'id' => $id

--- a/SurveyGizmo.php
+++ b/SurveyGizmo.php
@@ -52,7 +52,7 @@ class SurveyGizmoAPI
 	private static function testCredentials()
 	{
 		if (!Account::get() || !Account::get()->exists()) {
-			throw new SurveyGizmoException(SurveyGizmoException::NOT_AUTHORIZED);
+			throw new SurveyGizmoException('', SurveyGizmoException::NOT_AUTHORIZED);
 		}
 	}
 


### PR DESCRIPTION
Addresses the following error I was experiencing:

```Fatal error: Uncaught ArgumentCountError: Too few arguments to function SurveyGizmo\Helpers\SurveyGizmoException::__construct(), 1 passed in ```

```ArgumentCountError: Too few arguments to function SurveyGizmo\Helpers\SurveyGizmoException::__construct(), 1 passed in ```

![image](https://cloud.githubusercontent.com/assets/231052/25240240/f08eb9f6-25b7-11e7-99e4-b6840305cb7f.png)

Also fixes the signature of the SurveyGizmoException such that it matches \Exception, which it extends.
